### PR TITLE
vercel was created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel


### PR DESCRIPTION
i install vercel with commands 'yarn global add vercel' and 'vercel --prod'.GitHub repository only contains the .gitignore file within the .vercel directory. To deploy to production (for-fun-gules.vercel.app), run `vercel --prod`.To see deploys only run with command 'vercel --prod' or only 'vercel'
