### PR TITLE
added antd mobile skeleton to project

### DIFF
--- a/src/common/mobileSkeleton/index.scss
+++ b/src/common/mobileSkeleton/index.scss
@@ -1,0 +1,5 @@
+.customSkeleton {
+  --width: 70%;
+  --height: 100px;
+  --border-radius: 8px;
+}

--- a/src/common/mobileSkeleton/mobileSkeleton.tsx
+++ b/src/common/mobileSkeleton/mobileSkeleton.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Skeleton } from 'antd-mobile'
+import './index.scss'
+import {DemoBlock} from "../../demos/demo-block";
+const MobileSkeleton = () => {
+  return (
+    <>
+      <DemoBlock title='基础用法'>
+        <Skeleton.Title />
+        <Skeleton.Paragraph />
+      </DemoBlock>
+      <DemoBlock title='有动画的骨架屏'>
+        <Skeleton.Title animated />
+        <Skeleton.Paragraph lineCount={5} animated />
+      </DemoBlock>
+      <DemoBlock title='自定义'>
+        <Skeleton animated className='customSkeleton' />
+      </DemoBlock>
+    </>
+  )
+}
+
+export default MobileSkeleton;

--- a/src/demos/demo-block/index.scss
+++ b/src/demos/demo-block/index.scss
@@ -1,0 +1,23 @@
+.demoBlock {
+  margin-bottom: 12px;
+  &:last-of-type {
+    padding-bottom: 32px;
+  }
+}
+
+.title {
+  padding: 12px 12px 8px;
+  color: #697b8c;
+  font-size: 14px;
+}
+
+html[data-prefers-color-scheme='dark'] {
+  .title {
+    color: #959da6;
+  }
+}
+
+.main {
+  border-right: none;
+  border-left: none;
+}

--- a/src/demos/demo-block/index.tsx
+++ b/src/demos/demo-block/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import type { FC, ReactNode } from 'react'
+import './index.scss'
+
+interface Props {
+  title: string
+  padding?: string
+  background?: string
+  children?: ReactNode
+}
+
+export const DemoBlock: FC<Props> = props => {
+  return (
+    <div className='demoBlock'>
+      <div className='title'>{props.title}</div>
+      <div
+        className='main'
+        style={{
+          padding: props.padding,
+          background: props.background,
+        }}
+      >
+        {props.children}
+      </div>
+    </div>
+  )
+}
+
+DemoBlock.defaultProps = {
+  padding: '12px 12px',
+  background: 'var(--adm-color-background)',
+}


### PR DESCRIPTION
Added a Skeleton component using the antd-mobile library.Demos is not an npm package, but an alias created in the antd-mobile project. Its implementation is [here](https://github.com/ant-design/ant-design-mobile/blob/master/src/demos/index.ts).

Please don't try npm install demos. You can just ignore them.